### PR TITLE
Remove unnecessary checks

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ const crypto = require('crypto');
 const keypair = require('keypair')
 
 exports.generate = ( sizeInBits ) => {
-  if( !(typeof sizeInBits==='number' && (sizeInBits%1)===0 && (sizeInBits == 1024 || sizeInBits == 2048)) ) throw Error("Error generating public and private key. Key size can only be 1024 or 2048. Example usage: ` let keys = QuickEncrypt.generate(2048); `");
+  if( !(sizeInBits === 1024 || sizeInBits === 2048) ) throw Error("Error generating public and private key. Key size can only be 1024 or 2048. Example usage: ` let keys = QuickEncrypt.generate(2048); `");
   return keypair( { bits: sizeInBits } )
 }
 


### PR DESCRIPTION
The typeof and modulo checks can be shortcutted by the checks for the specific numbers (with the triple equals to ensure no type coercion).